### PR TITLE
Fixing deprecated compiler constructs

### DIFF
--- a/src/v1/async.rs
+++ b/src/v1/async.rs
@@ -33,7 +33,7 @@ pub trait RunnableAsyncRequest<ResponseType> {
     fn send_to(
         &self,
         api: &AsyncApi,
-    ) -> Box<Future<Item = ResponseType, Error = reqwest::Error> + Send>;
+    ) -> Box<dyn Future<Item = ResponseType, Error = reqwest::Error> + Send>;
 }
 
 impl<'a, RequestType, ResponseType> RunnableAsyncRequest<ResponseType> for RequestType
@@ -44,7 +44,7 @@ where
     fn send_to(
         &self,
         api: &AsyncApi,
-    ) -> Box<Future<Item = ResponseType, Error = reqwest::Error> + Send> {
+    ) -> Box<dyn Future<Item = ResponseType, Error = reqwest::Error> + Send> {
         let endpoint = format!("{}/{}", api.url, self.get_endpoint());
 
         let future = api


### PR DESCRIPTION
Seems like `dyn` has to be explicitly stated in the current version of the compiler.

```
   Compiling giphy v0.3.0 (C:\Users\macie\Projects\giphy-rs)
warning: trait objects without an explicit `dyn` are deprecated
  --> src\v1\async.rs:36:14
   |
36 |     ) -> Box<Future<Item = ResponseType, Error = reqwest::Error> + Send>;
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = ResponseType, Error = reqwest::Error> + Send`
   |
   = note: `#[warn(bare_trait_objects)]` on by default
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>

warning: trait objects without an explicit `dyn` are deprecated
  --> src\v1\async.rs:47:14
   |
47 |     ) -> Box<Future<Item = ResponseType, Error = reqwest::Error> + Send> {
   |              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: use `dyn`: `dyn Future<Item = ResponseType, Error = reqwest::Error> + Send`
   |
   = warning: this was previously accepted by the compiler but is being phased out; it will become a hard error in the 2021 edition!
   = note: for more information, see issue #80165 <https://github.com/rust-lang/rust/issues/80165>

warning: 2 warnings emitted
```