### PR TITLE
Limiting Travis build to be only on master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,9 @@ language: rust
 rust:
 - stable
 cache: cargo
+branches:
+  only:
+  - master
 deploy:
   provider: cargo
   token:


### PR DESCRIPTION
This makes Travis build only master branch and open PR. No point in running separate branch-build for PRs or branches with no open PRs.