### PR TITLE
Switching Dependabot to weekly schedule

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -4,6 +4,8 @@ updates:
   - package-ecosystem: "rust:cargo"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "sunday"
+      time: "12:00"
     reviewers:
       - "maciej-makowski"


### PR DESCRIPTION
Weekly checks are more than enough.